### PR TITLE
Correctly handle name, label and layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM node:lts-slim
 
 WORKDIR /usr/src/app
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ var fetch = require("node-fetch");
 var PHOTON_URL = process.env.PHOTON_URL || "https://photon.komoot.de";
 var PORT = process.env.PORT || 8080;
 
+const { translateResults } = require("./translate.js");
+
 http
   .createServer(function(req, res) {
     let parsedUrl = url.parse(req.url, true);
@@ -91,41 +93,6 @@ function reverse(params, res) {
   } else {
     writeError(res, 400, "point.lat and point.lon are required");
   }
-}
-
-function translateResults(photonResult) {
-  let peliasResponse = {
-    features: []
-  };
-  photonResult.features.forEach(feature => {
-    if (feature.properties.state) {
-      feature.properties.region = feature.properties.state;
-      delete feature.properties.state;
-    }
-    if (feature.properties.postcode) {
-      feature.properties.postalcode = feature.properties.postcode;
-      delete feature.properties.postcode;
-    }
-    if (feature.properties.city) {
-      feature.properties.locality = feature.properties.city;
-    }
-    let originalname = feature.properties.name;
-    feature.properties.name = `${feature.properties.street || ""} ${feature.properties.housenumber || ""}`;
-    if ((!feature.properties.street || !feature.properties.housenumber) && originalname) {
-      feature.properties.name = originalname;
-    }
-    if (
-      !feature.properties.street &&
-      !feature.properties.housenumber &&
-      !originalname &&
-      feature.properties.postalcode
-    ) {
-      feature.properties.name = feature.properties.postalcode;
-    }
-
-    peliasResponse.features.push(feature);
-  });
-  return peliasResponse;
 }
 
 function writeError(res, statusCode, errorMessage) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,18 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -37,6 +49,16 @@
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "argparse": {
@@ -81,6 +103,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -90,6 +118,21 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
     },
     "caller-callsite": {
       "version": "2.0.0",
@@ -115,6 +158,12 @@
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -126,11 +175,66 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      }
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -178,6 +282,42 @@
         "which": "^1.2.9"
       }
     },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -194,6 +334,36 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-string-regexp": {
@@ -229,6 +399,15 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -238,6 +417,40 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-stdin": {
       "version": "7.0.0",
@@ -254,10 +467,60 @@
         "pump": "^3.0.0"
       }
     },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "hosted-git-info": {
@@ -304,10 +567,47 @@
         "resolve-from": "^3.0.0"
       }
     },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
       "dev": true
     },
     "is-ci": {
@@ -319,17 +619,68 @@
         "ci-info": "^2.0.0"
       }
     },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
     "is-directory": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -374,6 +725,21 @@
         "p-locate": "^4.1.0"
       }
     },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
+    },
     "lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -392,10 +758,108 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
+      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "mocha": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
+      "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.3",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "mri": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
       "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
     "multimatch": {
@@ -416,6 +880,16 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -433,6 +907,12 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -440,6 +920,40 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "once": {
@@ -503,6 +1017,12 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -513,6 +1033,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "pkg-dir": {
@@ -694,6 +1220,27 @@
         }
       }
     },
+    "readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.4"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -725,6 +1272,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "shebang-command": {
@@ -792,10 +1345,77 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
+      "integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
+      "integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "supports-color": {
@@ -805,6 +1425,15 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
       }
     },
     "type-fest": {
@@ -832,10 +1461,70 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {
@@ -843,6 +1532,107 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "dev": true
+    },
+    "yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   "devDependencies": {
     "husky": "^3.0.2",
     "prettier": "1.18.2",
-    "pretty-quick": "^1.11.1"
+    "pretty-quick": "^1.11.1",
+    "mocha": "*"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "author": "",
   "license": "MIT",

--- a/test/dresdener-str.json
+++ b/test/dresdener-str.json
@@ -1,0 +1,292 @@
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [12.558728022189667, 51.350201549999994],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 337025418,
+        "osm_type": "W",
+        "extent": [12.5555681, 51.351867, 12.562834, 51.3489058],
+        "country": "Germany",
+        "osm_key": "landuse",
+        "city": "Borsdorf",
+        "osm_value": "industrial",
+        "postcode": "04451",
+        "name": "Gewerbegebiet Dresdener Landstraße",
+        "state": "Saxony"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [10.5123184, 50.0404224],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 39636304,
+        "osm_type": "W",
+        "extent": [10.5115516, 50.0404224, 10.5123429, 50.0403272],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Haßfurt",
+        "osm_value": "residential",
+        "postcode": "97437",
+        "name": "Dresdener Straße",
+        "suburb": "Sylbach",
+        "state": "Bavaria"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [12.9700818, 51.0974582],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 25216401,
+        "osm_type": "W",
+        "extent": [12.9699859, 51.0976184, 12.9700818, 51.0974582],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Hartha",
+        "osm_value": "tertiary",
+        "postcode": "04746",
+        "name": "Dresdener Straße",
+        "state": "Saxony"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [13.4964474, 51.4128434],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 309831369,
+        "osm_type": "W",
+        "extent": [13.4964015, 51.4150962, 13.4966787, 51.4106826],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Röderland",
+        "osm_value": "primary",
+        "postcode": "04932",
+        "name": "Dresdener Straße",
+        "state": "Brandenburg"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [13.0296742, 51.0733523],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 159652603,
+        "osm_type": "W",
+        "extent": [13.0295235, 51.0734955, 13.0299275, 51.0731835],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Waldheim",
+        "osm_value": "secondary",
+        "postcode": "04736",
+        "name": "Dresdener Straße",
+        "state": "Saxony"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [14.3881186, 51.0955492],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 448742573,
+        "osm_type": "W",
+        "extent": [14.3878684, 51.0956408, 14.3883508, 51.0954818],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Wilthen",
+        "osm_value": "secondary",
+        "postcode": "02681",
+        "name": "Dresdener Straße",
+        "state": "Saxony"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [13.909208, 51.1145189],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 776617403,
+        "osm_type": "W",
+        "extent": [13.9083206, 51.1145199, 13.910595, 51.1145012],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Radeberg",
+        "osm_value": "secondary",
+        "postcode": "01454",
+        "name": "Dresdener Straße",
+        "suburb": "Lotzdorf",
+        "state": "Saxony"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [14.2842976, 51.0970158],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 25088970,
+        "osm_type": "W",
+        "extent": [14.2799879, 51.097437, 14.2886612, 51.0966116],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Neukirch/Lausitz",
+        "osm_value": "primary",
+        "postcode": "01904",
+        "name": "Dresdener Straße",
+        "state": "Saxony"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [14.2313662, 51.0997131],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 23496782,
+        "osm_type": "W",
+        "extent": [14.230748, 51.1002267, 14.2319306, 51.0996108],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Schmölln-Putzkau",
+        "osm_value": "residential",
+        "postcode": "01877",
+        "name": "Dresdener Straße",
+        "state": "Saxony"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [13.9609996, 51.148727],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 162745580,
+        "osm_type": "W",
+        "extent": [13.9608049, 51.148727, 13.9609996, 51.1484876],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Wachau",
+        "osm_value": "primary",
+        "postcode": "01454",
+        "name": "Dresdener Straße",
+        "state": "Saxony"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [14.2231545, 51.1032852],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 313490288,
+        "osm_type": "W",
+        "extent": [14.2228061, 51.1032994, 14.2233338, 51.103242],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Schmölln-Putzkau",
+        "osm_value": "primary",
+        "postcode": "01877",
+        "name": "Dresdener Straße",
+        "state": "Saxony"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [14.3701182, 51.0562135],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 260912655,
+        "osm_type": "W",
+        "extent": [14.3701182, 51.0562135, 14.3707081, 51.0560915],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Sohland an der Spree",
+        "osm_value": "primary",
+        "postcode": "02689",
+        "name": "Dresdener Straße",
+        "state": "Saxony"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [14.380718, 51.0959521],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 129434062,
+        "osm_type": "W",
+        "extent": [14.3804794, 51.0966097, 14.3816551, 51.0959521],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Wilthen",
+        "osm_value": "residential",
+        "postcode": "02681",
+        "name": "Dresdener Straße",
+        "state": "Saxony"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [14.169842, 51.5800641],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 240770034,
+        "osm_type": "W",
+        "extent": [14.1697, 51.580682, 14.1701415, 51.580054],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Welzow",
+        "osm_value": "living_street",
+        "postcode": "03119",
+        "name": "Dresdener Straße",
+        "state": "Brandenburg"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [14.1710704, 51.582711],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 175786114,
+        "osm_type": "W",
+        "extent": [14.1701415, 51.5846362, 14.1719289, 51.580682],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Welzow",
+        "osm_value": "residential",
+        "postcode": "03119",
+        "name": "Dresdener Straße",
+        "state": "Brandenburg"
+      }
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/test/grundschule.json
+++ b/test/grundschule.json
@@ -1,0 +1,194 @@
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [9.26732315383207, 49.795355],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 160277043,
+        "osm_type": "W",
+        "extent": [9.2671226, 49.7956221, 9.2677557, 49.7950421],
+        "country": "Germany",
+        "osm_key": "building",
+        "city": "Mönchberg",
+        "street": "Schulstraße",
+        "osm_value": "yes",
+        "postcode": "63933",
+        "name": "Grundschule",
+        "state": "Bavaria"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [9.267054803201846, 49.795457549999995],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 160280883,
+        "osm_type": "W",
+        "extent": [9.2659402, 49.7960135, 9.2681658, 49.7949083],
+        "country": "Germany",
+        "osm_key": "amenity",
+        "city": "Mönchberg",
+        "street": "Schulstraße",
+        "osm_value": "school",
+        "postcode": "63933",
+        "name": "Grundschule",
+        "state": "Bavaria"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [8.916105851531878, 48.5817624],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 30493484,
+        "extent": [8.9159471, 48.5818246, 8.9162646, 48.5816677],
+        "country": "Germany",
+        "city": "Herrenberg",
+        "postcode": "71083",
+        "osm_type": "W",
+        "osm_key": "amenity",
+        "housenumber": "1",
+        "street": "Waldstraße",
+        "osm_value": "school",
+        "name": "Grundschule",
+        "suburb": "Mönchberg",
+        "state": "Baden-Württemberg"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [8.427924161053546, 48.09982905],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 32542269,
+        "osm_type": "W",
+        "extent": [8.427808, 48.0999062, 8.4280519, 48.0996391],
+        "country": "Germany",
+        "osm_key": "amenity",
+        "housenumber": "9",
+        "city": "Mönchweiler",
+        "street": "Innerdorf",
+        "osm_value": "school",
+        "postcode": "78087",
+        "name": "Grundschule",
+        "state": "Baden-Württemberg"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [8.600851516803823, 49.265247],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 542442131,
+        "osm_type": "W",
+        "extent": [8.6002927, 49.2656955, 8.6015969, 49.2645723],
+        "country": "Germany",
+        "osm_key": "amenity",
+        "city": "St. Leon-Rot",
+        "street": "Schulstraße",
+        "osm_value": "school",
+        "postcode": "68789",
+        "name": "Grundschule Mönchsbergschule",
+        "state": "Baden-Württemberg"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [8.847971302410652, 49.33371865],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 264872634,
+        "osm_type": "W",
+        "extent": [8.8477413, 49.3338598, 8.8482013, 49.3335775],
+        "country": "Germany",
+        "osm_key": "amenity",
+        "housenumber": "102",
+        "city": "Meckesheim",
+        "street": "Hauptstraße",
+        "osm_value": "school",
+        "postcode": "74909",
+        "name": "Grundschule Mönchzell",
+        "state": "Baden-Württemberg"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [8.91944287071772, 48.577861150000004],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 30493486,
+        "extent": [8.9193413, 48.57802, 8.9195661, 48.5776413],
+        "country": "Germany",
+        "city": "Herrenberg",
+        "postcode": "71083",
+        "osm_type": "W",
+        "osm_key": "amenity",
+        "housenumber": "3",
+        "street": "Mönchberger Straße",
+        "osm_value": "school",
+        "name": "Grundschule Kayh",
+        "suburb": "Kayh",
+        "state": "Baden-Württemberg"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [8.722476337829661, 49.04534815],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 5755143,
+        "extent": [8.7222492, 49.0455211, 8.7231094, 49.0451642],
+        "country": "Germany",
+        "city": "Bretten",
+        "postcode": "75015",
+        "osm_type": "R",
+        "osm_key": "amenity",
+        "housenumber": "3",
+        "street": "Mönchsstraße",
+        "osm_value": "school",
+        "name": "Grundschule Gölshausen",
+        "suburb": "Gölshausen",
+        "state": "Baden-Württemberg"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [8.6865031, 49.417557],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 736221550,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "housenumber": "18",
+        "city": "Heidelberg",
+        "street": "Mönchhofstraße",
+        "osm_value": "school",
+        "postcode": "69120",
+        "name": "Mönchhof-Grundschule",
+        "suburb": "Neuenheim",
+        "state": "Baden-Württemberg"
+      }
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/test/postbank.json
+++ b/test/postbank.json
@@ -1,0 +1,300 @@
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [7.011538973426834, 51.45054305],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 419502151,
+        "osm_type": "W",
+        "extent": [7.0106444, 51.4508582, 7.0123509, 51.4502655],
+        "country": "Germany",
+        "osm_key": "landuse",
+        "city": "Essen",
+        "osm_value": "commercial",
+        "postcode": "45128",
+        "name": "Postbank",
+        "state": "North Rhine-Westphalia"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [7.012474523340052, 51.4506582],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 35680648,
+        "osm_type": "W",
+        "extent": [7.0121946, 51.4509085, 7.0128015, 51.4503775],
+        "country": "Germany",
+        "osm_key": "highway",
+        "city": "Essen",
+        "osm_value": "pedestrian",
+        "postcode": "45128",
+        "name": "Postbank",
+        "state": "North Rhine-Westphalia"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [6.4454688, 51.1980911],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 338952015,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "housenumber": "6",
+        "city": "Mönchengladbach",
+        "neighbourhood": "Eicken",
+        "street": "Humboldtstraße",
+        "osm_value": "bank",
+        "postcode": "41061",
+        "name": "postbank",
+        "state": "North Rhine-Westphalia"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [13.4034421, 52.5691493],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 1287287816,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "city": "Berlin",
+        "street": "Mühlenstraße",
+        "osm_value": "bank",
+        "postcode": "13187",
+        "name": "Postbank",
+        "state": "Berlin"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [11.0310668, 50.9745384],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 6804096173,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "city": "Erfurt",
+        "street": "Anger",
+        "osm_value": "bank",
+        "postcode": "99084",
+        "name": "Postbank",
+        "state": "Thuringia"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [10.0424223, 53.5542291],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 660578172,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "city": "Hamburg",
+        "street": "Hammer Baum",
+        "osm_value": "bank",
+        "postcode": "20537",
+        "name": "Postbank",
+        "state": "Hamburg"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [13.3035461, 52.5257887],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 482219170,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "city": "Berlin",
+        "street": "Osnabrücker Straße",
+        "osm_value": "bank",
+        "postcode": "10589",
+        "name": "Postbank",
+        "state": "Berlin"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [13.2748851, 52.5367921],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 2425870256,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "city": "Berlin",
+        "street": "Popitzweg",
+        "osm_value": "bank",
+        "postcode": "13629",
+        "name": "Postbank",
+        "state": "Berlin"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [13.2775864, 52.5103293],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 1819283270,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "city": "Berlin",
+        "street": "Soorstraße",
+        "osm_value": "bank",
+        "postcode": "14050",
+        "name": "Postbank",
+        "state": "Berlin"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [13.493826, 52.6357339],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 1347625713,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "housenumber": "23",
+        "city": "Berlin",
+        "street": "Wiltbergstraße",
+        "osm_value": "bank",
+        "postcode": "13125",
+        "name": "Postbank",
+        "suburb": "Buch",
+        "state": "Berlin"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [13.3846979, 52.4847666],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 447946785,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "city": "Berlin",
+        "street": "Dudenstraße",
+        "osm_value": "bank",
+        "postcode": "10965",
+        "name": "Postbank",
+        "state": "Berlin"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [13.4237278, 52.4868431],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 420448903,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "housenumber": "1-6",
+        "city": "Berlin",
+        "neighbourhood": "Reuterkiez",
+        "street": "Hermannplatz",
+        "osm_value": "bank",
+        "postcode": "10967",
+        "name": "Postbank",
+        "state": "Berlin"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [12.9958009, 51.5599789],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 5237545632,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "housenumber": "6",
+        "city": "Torgau",
+        "street": "August-Bebel-Straße",
+        "osm_value": "bank",
+        "postcode": "04860",
+        "name": "Postbank",
+        "state": "Saxony"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [12.5203496, 49.1958019],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 3575091694,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "housenumber": "26",
+        "city": "Roding",
+        "street": "Schulstraße",
+        "osm_value": "bank",
+        "postcode": "93426",
+        "name": "Postbank",
+        "suburb": "Altstadt",
+        "state": "Bavaria"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [12.0178431, 51.4534891],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 3755861515,
+        "osm_type": "N",
+        "country": "Germany",
+        "osm_key": "amenity",
+        "housenumber": "147",
+        "city": "Halle (Saale)",
+        "street": "Leipziger Chaussee",
+        "osm_value": "bank",
+        "postcode": "06112",
+        "name": "Postbank",
+        "state": "Saxony-Anhalt"
+      }
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -9,10 +9,10 @@ it("correctly set a label", function() {
   assert.equal(result.features[0].properties.layer, "venue");
 
   assert.equal(result.features[10].properties.name, "Postbank");
-  assert.equal(result.features[10].properties.label, "Postbank, Dudenstraße, Berlin");
+  assert.equal(result.features[10].properties.label, "Postbank, Dudenstraße, 10965 Berlin");
 });
 
-it("correctly set a label for Grunschule", function() {
+it("correctly set a label for Grundschule", function() {
   const input = require("./grundschule.json");
   const result = translateResults(input);
   assert.equal(result.features[0].properties.name, "Grundschule");

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,7 @@ it("correctly set a label", function() {
   const result = translateResults(input);
   assert.equal(result.features[0].properties.name, "Postbank");
   assert.equal(result.features[0].properties.label, "Postbank, 45128 Essen");
+  assert.equal(result.features[0].properties.layer, "venue");
 
   assert.equal(result.features[10].properties.name, "Postbank");
   assert.equal(result.features[10].properties.label, "Postbank, Dudenstraße, Berlin");

--- a/test/test.js
+++ b/test/test.js
@@ -51,3 +51,54 @@ it("correctly set a label and name for Grundschule", function() {
     labels
   );
 });
+
+it("correctly set a label and name for Dresdener Straße", function() {
+  const input = require("./dresdener-str.json");
+  const result = translateResults(input);
+
+  const names = result.features.map(x => x.properties.name);
+
+  assert.deepEqual(
+    [
+      "Gewerbegebiet Dresdener Landstraße",
+      "Dresdener Straße",
+      "Dresdener Straße",
+      "Dresdener Straße",
+      "Dresdener Straße",
+      "Dresdener Straße",
+      "Dresdener Straße",
+      "Dresdener Straße",
+      "Dresdener Straße",
+      "Dresdener Straße",
+      "Dresdener Straße",
+      "Dresdener Straße",
+      "Dresdener Straße",
+      "Dresdener Straße",
+      "Dresdener Straße"
+    ],
+    names
+  );
+
+  const labels = result.features.map(x => x.properties.label);
+
+  assert.deepEqual(
+    [
+      "Gewerbegebiet Dresdener Landstraße, 04451 Borsdorf",
+      "Dresdener Straße, 97437 Haßfurt",
+      "Dresdener Straße, 04746 Hartha",
+      "Dresdener Straße, 04932 Röderland",
+      "Dresdener Straße, 04736 Waldheim",
+      "Dresdener Straße, 02681 Wilthen",
+      "Dresdener Straße, 01454 Radeberg",
+      "Dresdener Straße, 01904 Neukirch/Lausitz",
+      "Dresdener Straße, 01877 Schmölln-Putzkau",
+      "Dresdener Straße, 01454 Wachau",
+      "Dresdener Straße, 01877 Schmölln-Putzkau",
+      "Dresdener Straße, 02689 Sohland an der Spree",
+      "Dresdener Straße, 02681 Wilthen",
+      "Dresdener Straße, 03119 Welzow",
+      "Dresdener Straße, 03119 Welzow"
+    ],
+    labels
+  );
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 const assert = require("assert");
 const { translateResults } = require("../translate.js");
 
-it("correctly set a label", function() {
+it("correctly set a label and name for Postbank", function() {
   const input = require("./postbank.json");
   const result = translateResults(input);
   assert.equal(result.features[0].properties.name, "Postbank");
@@ -12,7 +12,7 @@ it("correctly set a label", function() {
   assert.equal(result.features[10].properties.label, "Postbank, Dudenstraße, 10965 Berlin");
 });
 
-it("correctly set a label for Grundschule", function() {
+it("correctly set a label and name for Grundschule", function() {
   const input = require("./grundschule.json");
   const result = translateResults(input);
   assert.equal(result.features[0].properties.name, "Grundschule");
@@ -32,5 +32,22 @@ it("correctly set a label for Grundschule", function() {
       "Mönchhof-Grundschule"
     ],
     names
+  );
+
+  const labels = result.features.map(x => x.properties.label);
+
+  assert.deepEqual(
+    [
+      "Grundschule, Schulstraße, 63933 Mönchberg",
+      "Grundschule, Schulstraße, 63933 Mönchberg",
+      "Grundschule, Waldstraße 1, 71083 Herrenberg",
+      "Grundschule, Innerdorf 9, 78087 Mönchweiler",
+      "Grundschule Mönchsbergschule, Schulstraße, 68789 St. Leon-Rot",
+      "Grundschule Mönchzell, Hauptstraße 102, 74909 Meckesheim",
+      "Grundschule Kayh, Mönchberger Straße 3, 71083 Herrenberg",
+      "Grundschule Gölshausen, Mönchsstraße 3, 75015 Bretten",
+      "Mönchhof-Grundschule, Mönchhofstraße 18, 69120 Heidelberg"
+    ],
+    labels
   );
 });

--- a/test/test.js
+++ b/test/test.js
@@ -17,4 +17,20 @@ it("correctly set a label for Grundschule", function() {
   const result = translateResults(input);
   assert.equal(result.features[0].properties.name, "Grundschule");
   assert.equal(result.features[0].properties.label, "Grundschule, Schulstraße, 63933 Mönchberg");
+  const names = result.features.map(x => x.properties.name);
+
+  assert.deepEqual(
+    [
+      "Grundschule",
+      "Grundschule",
+      "Grundschule",
+      "Grundschule",
+      "Grundschule Mönchsbergschule",
+      "Grundschule Mönchzell",
+      "Grundschule Kayh",
+      "Grundschule Gölshausen",
+      "Mönchhof-Grundschule"
+    ],
+    names
+  );
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,19 @@
+const assert = require("assert");
+const { translateResults } = require("../translate.js");
+
+it("correctly set a label", function() {
+  const input = require("./postbank.json");
+  const result = translateResults(input);
+  assert.equal(result.features[0].properties.name, "Postbank");
+  assert.equal(result.features[0].properties.label, "Postbank, 45128 Essen");
+
+  assert.equal(result.features[10].properties.name, "Postbank");
+  assert.equal(result.features[10].properties.label, "Postbank, Dudenstraße, Berlin");
+});
+
+it("correctly set a label for Grunschule", function() {
+  const input = require("./grundschule.json");
+  const result = translateResults(input);
+  assert.equal(result.features[0].properties.name, "Grundschule");
+  assert.equal(result.features[0].properties.label, "Grundschule, Schulstraße, 63933 Mönchberg");
+});

--- a/translate.js
+++ b/translate.js
@@ -29,7 +29,10 @@ exports.translateResults = photonResult => {
       feature.properties.locality = feature.properties.city;
     }
 
+    // in digitransit name is displayed in the first line and label in the second one
     feature.properties.label = getLabel(feature.properties);
+    // `venue` is also applied to addresses but for the purpose of digitransit it does
+    // not matter: https://github.com/mfdz/digitransit-ui/blob/master/app/util/suggestionUtils.js#L54
     feature.properties.layer = "venue";
 
     peliasResponse.features.push(feature);

--- a/translate.js
+++ b/translate.js
@@ -28,19 +28,6 @@ exports.translateResults = photonResult => {
     if (feature.properties.city) {
       feature.properties.locality = feature.properties.city;
     }
-    let originalname = feature.properties.name;
-    feature.properties.name = `${feature.properties.street || ""} ${feature.properties.housenumber || ""}`;
-    if ((!feature.properties.street || !feature.properties.housenumber) && originalname) {
-      feature.properties.name = originalname;
-    }
-    if (
-      !feature.properties.street &&
-      !feature.properties.housenumber &&
-      !originalname &&
-      feature.properties.postalcode
-    ) {
-      feature.properties.name = feature.properties.postalcode;
-    }
 
     feature.properties.label = getLabel(feature.properties);
     feature.properties.layer = "venue";

--- a/translate.js
+++ b/translate.js
@@ -1,0 +1,50 @@
+const getLabel = properties => {
+  const { name, street, housenumber, postalcode, city } = properties;
+  const result = [properties.name];
+  if (street) {
+    const num = housenumber || "";
+    result.push(`${street} ${num}`.trim());
+  }
+  if (city) {
+    const pc = postalcode || "";
+    result.push(`${pc} ${city}`);
+  }
+  return result.join(", ");
+};
+
+exports.translateResults = photonResult => {
+  let peliasResponse = {
+    features: []
+  };
+  photonResult.features.forEach(feature => {
+    if (feature.properties.state) {
+      feature.properties.region = feature.properties.state;
+      delete feature.properties.state;
+    }
+    if (feature.properties.postcode) {
+      feature.properties.postalcode = feature.properties.postcode;
+      delete feature.properties.postcode;
+    }
+    if (feature.properties.city) {
+      feature.properties.locality = feature.properties.city;
+    }
+    let originalname = feature.properties.name;
+    feature.properties.name = `${feature.properties.street || ""} ${feature.properties.housenumber || ""}`;
+    if ((!feature.properties.street || !feature.properties.housenumber) && originalname) {
+      feature.properties.name = originalname;
+    }
+    if (
+      !feature.properties.street &&
+      !feature.properties.housenumber &&
+      !originalname &&
+      feature.properties.postalcode
+    ) {
+      feature.properties.name = feature.properties.postalcode;
+    }
+
+    feature.properties.label = getLabel(feature.properties);
+
+    peliasResponse.features.push(feature);
+  });
+  return peliasResponse;
+};

--- a/translate.js
+++ b/translate.js
@@ -43,6 +43,7 @@ exports.translateResults = photonResult => {
     }
 
     feature.properties.label = getLabel(feature.properties);
+    feature.properties.layer = "venue";
 
     peliasResponse.features.push(feature);
   });


### PR DESCRIPTION
We've had complaints about POI names not being displayed in the search result so I took some time to investigate what digitransit actually expects.

It turns out that if you set `layer=venue` then the `name` is displayed in the first line and `label` in the second.

In the end it looks like this: 

![Screenshot from 2020-04-01 22-21-36](https://user-images.githubusercontent.com/151346/78232021-f83ead00-74d3-11ea-8cf9-15ce731aa954.png)

I took the liberty to completely remove the transformation of `name` and instead add the correct `label` property. I also added a fairly thorough test suit that uses actual photon JSON output.

Also, I switched to the `slim` variant of the docker base image and this reduces the image size from around 900 to 170 MB. 

Fixes #1.