### PR TITLE
Add correct name and label for exact addresses

### DIFF
--- a/test/address-with-housenumber.json
+++ b/test/address-with-housenumber.json
@@ -1,0 +1,65 @@
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [8.941464689570829, 48.6604666],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 181514636,
+        "osm_type": "W",
+        "extent": [8.9413802, 48.6605297, 8.9415492, 48.6604034],
+        "country": "Germany",
+        "osm_key": "building",
+        "housenumber": "5",
+        "city": "Ehningen",
+        "street": "Bahnhofstraße",
+        "osm_value": "yes",
+        "postcode": "71139",
+        "state": "Baden-Württemberg"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [8.906460461686692, 48.64138985],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 60096654,
+        "osm_type": "W",
+        "extent": [8.9063903, 48.6414391, 8.9065304, 48.641339],
+        "country": "Germany",
+        "osm_key": "building",
+        "housenumber": "5/1",
+        "city": "Gärtringen",
+        "street": "Bahnhofstraße",
+        "osm_value": "yes",
+        "postcode": "71116",
+        "state": "Baden-Württemberg"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [8.906333028179723, 48.64126975],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 60096655,
+        "osm_type": "W",
+        "extent": [8.90626, 48.6413309, 8.9064061, 48.6412086],
+        "country": "Germany",
+        "osm_key": "building",
+        "housenumber": "5",
+        "city": "Gärtringen",
+        "street": "Bahnhofstraße",
+        "osm_value": "yes",
+        "postcode": "71116",
+        "state": "Baden-Württemberg"
+      }
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -102,3 +102,21 @@ it("correctly set a label and name for Dresdener Straße", function() {
     labels
   );
 });
+
+it("set a label and name for an exact address with house number", function() {
+  const input = require("./address-with-housenumber.json");
+  const { features } = translateResults(input);
+
+  const labels = features.map(x => x.properties.label);
+
+  assert.deepEqual(
+    ["Bahnhofstraße 5, 71139 Ehningen", "Bahnhofstraße 5/1, 71116 Gärtringen", "Bahnhofstraße 5, 71116 Gärtringen"],
+    labels
+  );
+
+  const names = features.map(x => x.properties.name);
+  assert.deepEqual(
+    ["Bahnhofstraße 5, 71139 Ehningen", "Bahnhofstraße 5/1, 71116 Gärtringen", "Bahnhofstraße 5, 71116 Gärtringen"],
+    names
+  );
+});

--- a/translate.js
+++ b/translate.js
@@ -1,6 +1,9 @@
 const getLabel = properties => {
   const { name, street, housenumber, postalcode, city } = properties;
-  const result = [properties.name];
+  const result = [];
+  if (name) {
+    result.push(name);
+  }
   if (street) {
     const num = housenumber || "";
     result.push(`${street} ${num}`.trim());
@@ -10,6 +13,16 @@ const getLabel = properties => {
     result.push(`${pc} ${city}`);
   }
   return result.join(", ");
+};
+
+// if we already have a name, we keep it.
+// exact addresses (with house numbers) don't have a name
+// so we will use the label instead.
+const getName = properties => {
+  const { name, label } = properties;
+  if (name) {
+    return name;
+  } else return label;
 };
 
 exports.translateResults = photonResult => {
@@ -31,6 +44,7 @@ exports.translateResults = photonResult => {
 
     // in digitransit name is displayed in the first line and label in the second one
     feature.properties.label = getLabel(feature.properties);
+    feature.properties.name = getName(feature.properties);
     // `venue` is also applied to addresses but for the purpose of digitransit it does
     // not matter: https://github.com/mfdz/digitransit-ui/blob/master/app/util/suggestionUtils.js#L54
     feature.properties.layer = "venue";


### PR DESCRIPTION
My previous PR introduced a problem with exact addresses that include the house number.

They would display as " , Schlehenweg 5, 71139 Ehningen".

With this PR I fixed this and added a test so it doesn't happen again.

The result looks like this:

![Screenshot from 2020-04-08 11-26-28](https://user-images.githubusercontent.com/151346/78768769-acd14680-798c-11ea-8e7b-1cb64bb77e3e.png)

/cc @hbruch