### PR TITLE
Make adapter compatible with next version of digitransit-ui

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: test
+    if: ${{ github.ref == 'refs/heads/master' }}
     steps:
       - uses: actions/checkout@v2
       - name: Publish to Dockerhub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,16 @@ jobs:
         run: npm install
       - name: Unit tests
         run: npm test
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish to Dockerhub
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: ${{ github.repository }}
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_AUTH}}
+          tags: "latest,${{ github.sha }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Run tests
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    name: Run tests
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "10"
+      - name: Install dependencies
+        run: npm install
+      - name: Unit tests
+        run: npm test

--- a/index.js
+++ b/index.js
@@ -31,7 +31,11 @@ function search(params, res) {
   let focusParam = null;
 
   //ignore GTFS stop requests. Used by digitransit
-  if (params["sources"] && params["sources"].split(",").includes("gtfs")) {
+  if (
+    params["sources"] &&
+    params["sources"].split(",").length == 1 &&
+    params["sources"].split(",")[0].startsWith("gtfs")
+  ) {
     res.writeHead(404, {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*"

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function search(params, res) {
   let bboxParam = null;
 
   //ignore GTFS stop requests. Used by digitransit
-  if (params["sources"] && params["sources"].includes("gtfs")) {
+  if (params["sources"] && params["sources"].split(",").includes("gtfs")) {
     res.writeHead(404, {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*"


### PR DESCRIPTION
In the next version of digitransit (preview of our fork here: https://next.stadtnavi.eu/) DT no longer makes two requests per search but puts it all into one. It also appends the config name ("hb") to the word "gtfs": https://github.com/HSLdevcom/digitransit-ui/blob/next/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js#L330

So for this adapter to work for both versions I'm parsing the list and make sure that only those requests fail where there is only one element starting with `gtfs`.

On top of it I'm running the tests through Github Action.